### PR TITLE
Add optionals constrains

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ end
 ```
 
 It is possible to add constraints that are not required to comply. If we are using an optional constraint
-and, with the resulting filter, we'll get an empty result then the constraint will be ignored.
+and, with the resulting filter, we'll get an empty result then the constraint will be ignored. If two or more
+optional constraints are added the addition order will be important: the last one will be the first constraint
+to be removed (if we didn't get results), and so on.
 
 ```ruby
 class Offer < ActiveRecord::Base

--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ class Offer < ActiveRecord::Base
 end
 ```
 
+It is possible to add constraints that are not required to comply. If we are using an optional constraint
+and, with the resulting filter, we'll get an empty result then the constraint will be ignored.
+
+```ruby
+class Offer < ActiveRecord::Base
+
+  include ActsAsConstrained::Concerns::Constrained
+
+  constrain_by :model
+  constrain_by :single_date, optional: true
+
+end
+```
+
 ## Constraints
 
 Currently there are 3 implemented constraints: by multiple dates, a single date

--- a/app/models/acts_as_constrained/concerns/constrained.rb
+++ b/app/models/acts_as_constrained/concerns/constrained.rb
@@ -74,7 +74,7 @@ module ActsAsConstrained::Concerns
         loop do
           break if opt_constraints.blank?
 
-          result_with_optionals = build_constraints result_with_required, opt_constraints, true
+          result_with_optionals = build_constraints result_with_required, opt_constraints
           if result_with_optionals.count > 0
             result = result_with_optionals and break
           else
@@ -85,12 +85,12 @@ module ActsAsConstrained::Concerns
         result
       end
 
-      def self.build_constraints scope, constraints, optional=false
+      def self.build_constraints scope, constraints
         constraints.inject(scope) { |scope, constraint|
           # We get the constraint kinds and params
           constraint_kind, constraint_values = constraint
           # Now we chain a new scope using the constraint_values as params
-          scope.send "constrained_by_#{constraint_kind}", constraint_values unless optional && constraint_values.blank?
+          scope.send "constrained_by_#{constraint_kind}", constraint_values
         }
       end
     end

--- a/app/models/acts_as_constrained/concerns/constrained.rb
+++ b/app/models/acts_as_constrained/concerns/constrained.rb
@@ -86,7 +86,7 @@ module ActsAsConstrained::Concerns
       end
 
       def self.build_constraints scope, constraints, optional=false
-        constraints.inject(scope) { |result, constraint|
+        constraints.inject(scope) { |scope, constraint|
           # We get the constraint kinds and params
           constraint_kind, constraint_values = constraint
           # Now we chain a new scope using the constraint_values as params

--- a/spec/dummy/app/models/hotel.rb
+++ b/spec/dummy/app/models/hotel.rb
@@ -1,0 +1,8 @@
+class Hotel < ActiveRecord::Base
+
+  include ActsAsConstrained::Concerns::Constrained
+
+  constrain_by :model
+  constrain_by :date, optional: true
+
+end

--- a/spec/dummy/db/migrate/20160706140139_create_hotels.rb
+++ b/spec/dummy/db/migrate/20160706140139_create_hotels.rb
@@ -1,0 +1,9 @@
+class CreateHotels < ActiveRecord::Migration
+  def change
+    create_table :hotels do |t|
+      t.string :name
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150817110739) do
+ActiveRecord::Schema.define(version: 20160706140139) do
 
   create_table "acts_as_constrained_date_constraints", force: :cascade do |t|
     t.date    "starts_at"
@@ -33,6 +33,12 @@ ActiveRecord::Schema.define(version: 20150817110739) do
   add_index "acts_as_constrained_model_constraints", ["constraining_type", "constraining_id"], name: "index_model_constraints_on_constraining_type_and_id"
 
   create_table "countries", force: :cascade do |t|
+    t.string   "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "hotels", force: :cascade do |t|
     t.string   "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/factories/hotels_factory.rb
+++ b/spec/factories/hotels_factory.rb
@@ -1,0 +1,7 @@
+# Read about factories at https://github.com/thoughtbot/factory_girl
+
+FactoryGirl.define do
+  factory :hotel do
+    name { Faker::Lorem.sentence }
+  end
+end

--- a/spec/models/acts_as_constrained/multiple_constraints_spec.rb
+++ b/spec/models/acts_as_constrained/multiple_constraints_spec.rb
@@ -101,8 +101,6 @@ describe ActsAsConstrained do
         )]
     end
 
-    let!(:valid_results) { [good_date_good_market_hotel, bad_date_good_market_hotel] }
-
     let(:market) { create :market }
 
     before do
@@ -113,8 +111,10 @@ describe ActsAsConstrained do
     subject { hotel }
 
     it "should find the hotels when filtered by the optional constraints" do
-      expect(Hotel.constrained_by(model: [market])).to match_array valid_results
-      expect(Hotel.constrained_by(date: Time.now, model: [market])).to match_array valid_results
+      expect(Hotel.constrained_by(model: [market])).to match_array [good_date_good_market_hotel, bad_date_good_market_hotel]
+      expect(Hotel.constrained_by(date: Time.now, model: [market])).to match_array [good_date_good_market_hotel]
+      expect(Hotel.constrained_by(date: 15.days.from_now, model: [market])).to match_array [bad_date_good_market_hotel]
+      expect(Hotel.constrained_by(date: 45.days.from_now, model: [market])).to match_array [good_date_good_market_hotel, bad_date_good_market_hotel]
     end
   end
 

--- a/spec/models/acts_as_constrained/multiple_constraints_spec.rb
+++ b/spec/models/acts_as_constrained/multiple_constraints_spec.rb
@@ -77,9 +77,45 @@ describe ActsAsConstrained do
         Offer.constrained_by(date: Time.now, model: [market, country])
       ).to match_array [good_date_good_market_offer_with_country]
     end
+  end
 
+  context "when filtering by optional constraints" do
 
+    let!(:good_date_good_market_hotel) do
+      create :hotel,
+        model_constraints: [
+          create(:model_constraint, constraining: market),
+        ],
+        date_constraints: [create(:date_constraint,
+          starts_at: 7.days.ago,
+          ends_at: 7.days.from_now
+        )]
+    end
 
+    let!(:bad_date_good_market_hotel) do
+      create :hotel,
+        model_constraints: [create(:model_constraint, constraining: market)],
+        date_constraints: [create(:date_constraint,
+          starts_at: 7.days.from_now,
+          ends_at: 17.days.from_now
+        )]
+    end
+
+    let!(:valid_results) { [good_date_good_market_hotel, bad_date_good_market_hotel] }
+
+    let(:market) { create :market }
+
+    before do
+      create :hotel
+      create :hotel
+    end
+
+    subject { hotel }
+
+    it "should find the hotels when filtered by the optional constraints" do
+      expect(Hotel.constrained_by(model: [market])).to match_array valid_results
+      expect(Hotel.constrained_by(date: Time.now, model: [market])).to match_array valid_results
+    end
   end
 
 end


### PR DESCRIPTION
It is possible to add constraints that are not required to comply. If we are using an optional constraint and, with the resulting filter, we'll get an empty result then the constraint will be ignored.

constrain_by :single_date, **optional: true**
